### PR TITLE
Add root-folder installation to npm-install script

### DIFF
--- a/npm-install.js
+++ b/npm-install.js
@@ -3,6 +3,10 @@ var { exec } = require('child_process'); // native in nodeJs
 // commands list
 const commands = [
     {
+        name: 'App',
+        command: `cd . && npm i`
+    },
+    {
         name: 'Frontend',
         command: `cd ./frontend && npm i`
     },


### PR DESCRIPTION
Added "npm i" for the root folder in the npm-module-installation-script, as this is necessary (e.g. dotenv) for succesfully running the other installation-scripts.